### PR TITLE
Set mantine default colorscheme to dark

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <ColorSchemeScript />
+        <ColorSchemeScript defaultColorScheme="dark" />
       </head>
       <body className={inter.className}>
         <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
Mantine was flashing white for a split second on load while color scheme setting was being injected. This sets a default scheme in the html to avoid it.