### PR TITLE
Show error on creation when it is caused in pre transaction verification

### DIFF
--- a/src/hooks/TokenStreamingAbi.ts
+++ b/src/hooks/TokenStreamingAbi.ts
@@ -80,7 +80,10 @@ export const useCreateStream = (
           gasLimit: 1000000,
           variableOutputs: 2,
         })
-        .call();
+        .call()
+        .catch((e: Error) => {
+          setError(e.message);
+        });
 
       if (response?.transactionResult.isStatusFailure) {
         setIsLoading(false);


### PR DESCRIPTION
Error shown in notification bar for errors triggered before sending of the transaction is complete.